### PR TITLE
fix unauthenticated_action so it actually gets used

### DIFF
--- a/lib/rails_warden/controller_mixin.rb
+++ b/lib/rails_warden/controller_mixin.rb
@@ -45,6 +45,12 @@ module RailsWarden
       # Proxy to the authenticate method on warden
       # :api: public
       def authenticate!(*args)
+        defaults = {:action => RailsWarden.unauthenticated_action}
+        if args.last.is_a? Hash
+          args[-1] = defaults.merge(args.last)
+        else
+          args << defaults
+        end
         warden.authenticate!(*args)
       end
 


### PR DESCRIPTION
The `Warden::Manager.before_failure` hook from rails_warden.rb gets called too late to get the action right—Warden sets a default action of 'unauthorized' in `Warden::Manager#process_unauthenticated` if none gets passed in. This change makes rails_warden's `#authenticate!` helper _always_ set the `:action` option.
