### PR TITLE
Rails 5 Support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,3 @@ group :test do
   gem 'rspec', '>= 2.0'
   gem 'bump'
 end
-

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ RSpec::Core::RakeTask.new(:spec)
 
 desc "Run tests against all other versions of Rails (!run task without 'bundle exec'!)"
 task :all do
-  versions = %w[~>2 ~>3.0.0 ~>3.1.0]
+  versions = %w[~>2 ~>3.0.0 ~>3.1.0 ~>5.0.0]
   versions.each do |version|
     sh "export RAILS_VERSION='#{version}' && (bundle check || bundle update) && bundle exec rake"
   end

--- a/lib/rails_warden.rb
+++ b/lib/rails_warden.rb
@@ -88,7 +88,7 @@ if !defined?(Rails::Railtie)
 else
   class RailsWarden::Railtie < Rails::Railtie
     include_block = Proc.new {
-      
+
       ActiveSupport.on_load(:action_controller) do
         ::ActionController::Base.class_eval do
           include RailsWarden::Mixins::HelperMethods
@@ -97,11 +97,12 @@ else
         if defined? ::ActionController::API
           ::ActionController::API.class_eval do
             include RailsWarden::Mixins::HelperMethods
-            include RailsWarden::Mixins::ControllerOnlyMethods
-            # TODO use the Rails 5 helper vs include
-            # /Users/jspooner/v/rails_warden/lib/rails_warden.rb:100:in `block (3 levels) in <class:Railtie>': undefined method `helper' for ActionController::API:Class (NoMethodError)
-            # helper RailsWarden::Mixins::HelperMethods
-            # helper RailsWarden::Mixins::ControllerOnlyMethods
+
+            if defined? helper
+              helper RailsWarden::Mixins::ControllerOnlyMethods
+            else
+              include RailsWarden::Mixins::ControllerOnlyMethods
+            end
           end
         end
       end


### PR DESCRIPTION
**Changes**

When the class_eval methods were not wrapped in an on_load block I was getting strange results where my helpers in the including project were wiped out. I noticed all Railsies in the Rails project has this on_load block.
a) class_eval needed to be wrapped in a ActiveSupport.on_load(:action_controller) block
b) ActionView::Base class_eval was clobbering existing controller helpers when not wrapped in a ActiveSupport.on_load(:action_view) block

If the rails version has ::ActionController::API we also add the helper methods there also.

Rails 5 has a new view on including helpers in controllers. We now call helper vs include
rails/rails#24866