### PR TITLE
Add Ruby `3.1`, `3.2` and RoR `7` to the matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -42,7 +42,7 @@ jobs:
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         gemfile: [rails50, rails51, rails52, rails60, rails61]
-        ruby: ["2.5", "2.6", "2.7", "3.0"]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2"]
         exclude:
           - gemfile: rails50
             ruby: "3.0"
@@ -22,6 +22,18 @@ jobs:
             ruby: "3.0"
           - gemfile: rails52
             ruby: "3.0"
+          - gemfile: rails50
+            ruby: "3.1"
+          - gemfile: rails51
+            ruby: "3.1"
+          - gemfile: rails52
+            ruby: "3.1"
+          - gemfile: rails50
+            ruby: "3.2"
+          - gemfile: rails51
+            ruby: "3.2"
+          - gemfile: rails52
+            ruby: "3.2"
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gemfile: [rails50, rails51, rails52, rails60, rails61]
+        gemfile: [rails50, rails51, rails52, rails60, rails61, rails70]
         ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2"]
         exclude:
-          - gemfile: rails50
+          - gemfile: rails50g
             ruby: "3.0"
           - gemfile: rails51
             ruby: "3.0"
@@ -34,6 +34,10 @@ jobs:
             ruby: "3.2"
           - gemfile: rails52
             ruby: "3.2"
+          - gemfile: rails70
+            ruby: "2.5"
+          - gemfile: rails70
+            ruby: "2.6"
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/gemfiles/rails70.gemfile
+++ b/gemfiles/rails70.gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+gemspec path: '../'
+
+group :development, :test do
+  gem 'rails', '~> 7.0.0'
+end


### PR DESCRIPTION
In this pull request, I have added Ruby `3.1`, `3.2`, and RoR `7` to the matrix. Also, bump `acrtions/checkout` action to `v4`.