### PR TITLE
Drop EOL rubies + Rails pre-7 tests + update for recent rubies

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gemfile: [rails60, rails61, rails70, rails71, rails72]
+        gemfile: [rails70, rails71, rails72]
         ruby: ["3.2", "3.3", "3.4"]
 
     env:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,31 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gemfile: [rails50, rails51, rails52, rails60, rails61, rails70]
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2"]
-        exclude:
-          - gemfile: rails50g
-            ruby: "3.0"
-          - gemfile: rails51
-            ruby: "3.0"
-          - gemfile: rails52
-            ruby: "3.0"
-          - gemfile: rails50
-            ruby: "3.1"
-          - gemfile: rails51
-            ruby: "3.1"
-          - gemfile: rails52
-            ruby: "3.1"
-          - gemfile: rails50
-            ruby: "3.2"
-          - gemfile: rails51
-            ruby: "3.2"
-          - gemfile: rails52
-            ruby: "3.2"
-          - gemfile: rails70
-            ruby: "2.5"
-          - gemfile: rails70
-            ruby: "2.6"
+        gemfile: [rails60, rails61, rails70, rails71, rails72]
+        ruby: ["3.2", "3.3", "3.4"]
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-gemspec path: '../'
-
-group :development, :test do
-  gem 'rails', '~> 5.2.0'
-end

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-gemspec path: '../'
-
-group :development, :test do
-  gem 'rails', '~> 6.0.0'
-end

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-gemspec path: '../'
-
-group :development, :test do
-  gem 'rails', '~> 6.1.0'
-end

--- a/gemfiles/rails71.gemfile
+++ b/gemfiles/rails71.gemfile
@@ -4,5 +4,5 @@ source 'https://rubygems.org'
 gemspec path: '../'
 
 group :development, :test do
-  gem 'rails', '~> 5.1.0'
+  gem 'rails', '~> 7.1.0'
 end

--- a/gemfiles/rails72.gemfile
+++ b/gemfiles/rails72.gemfile
@@ -4,5 +4,5 @@ source 'https://rubygems.org'
 gemspec path: '../'
 
 group :development, :test do
-  gem 'rails', '~> 5.0.0'
+  gem 'rails', '~> 7.2.0'
 end

--- a/rails_warden.gemspec
+++ b/rails_warden.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "ostruct"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require "rails"
 require "rails_warden"
 
 require "action_controller"
+require "ostruct"
 
 $TESTING=true
 


### PR DESCRIPTION
Subject pretty much covers it and tests pass.

* Drops: 
  * Ruby 3.1 and below.
  * Rails pre-7
* Adds:
  * Ruby 3.2, 3.3, 3.4
  * Rails 7.1, 7.2